### PR TITLE
adds installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ This package is currently an early access release.  You should also install the 
 * Go to definition
 * Hover
 
+## Getting Started
+
+Install ide-typescript from "Install" in Atom's settings or run:
+
+`apm install ide-typescript`
+
 ## Contributing
 Always feel free to help out!  Whether it's [filing bugs and feature requests](https://github.com/atom/languageserver-typescript/issues/new) or working on some of the [open issues](https://github.com/atom/languageserver-typescript/issues), Atom's [contributing guide](https://github.com/atom/atom/blob/master/CONTRIBUTING.md) will help get you started while the [guide for contributing to packages](https://github.com/atom/atom/blob/master/docs/contributing-to-packages.md) has some extra information.
 


### PR DESCRIPTION
Adds installation package instructions

Install ide-typescript from "Install" in Atom's settings or run:

```apm install ide-typescript```