### PR TITLE
Remove info regarding Atom 1.21 Beta from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 TypeScript and JavaScript language support for Atom-IDE, powered by the [Sourcegraph TypeScript Language Server](https://github.com/sourcegraph/javascript-typescript-langserver).
 
-**Requires [Atom 1.21](https://atom.io/beta) - currently in beta**
-
 ![Screen shot of IDE-TypeScript](https://user-images.githubusercontent.com/118951/30306800-37e3c506-972f-11e7-805c-ba5a45a6bc3c.png)
 
 ## Early access


### PR DESCRIPTION
Atom 1.21 has been promoted to stable channel recently and is no longer beta: http://blog.atom.io/2017/10/03/atom-1-21.html

I think this information can be safely removed now.