### PR TITLE
Add filterChangeWatchedFiles implementation

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -8,6 +8,7 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
   getServerName () { return 'SourceGraph' }
 
   startServerProcess () {
+    this.supportedExtensions = atom.config.get('ide-typescript.javascriptSupport') ? [ '.ts', '.tsx', '*.json', '.js', '.jsx' ] : [ '.ts', '.tsx', '*.json' ]
     const args = [ 'node_modules/javascript-typescript-langserver/lib/language-server-stdio' ]
     return super.spawnChildNode(args, { cwd: path.join(__dirname, '..') })
   }
@@ -134,6 +135,10 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
         suggestion.leftLabel = ''
       }
     }
+  }
+
+  filterChangeWatchedFiles(filePath) {
+    return this.supportedExtensions.indexOf(path.extname(filePath).toLowerCase()) > -1;
   }
 }
 


### PR DESCRIPTION
This change adds an implementation for filterChangeWatchedFiles so that the language client doesn't send change notifications for non-TypeScript (or JavaScript) files inside of a project folder.  This requires `atom-languageclient` functionality on `master` so we should ship this when we release an update to the other.

**Question:** Should we consider adding some kind of built-in capability in atom-languageclient for extension-based path filtering for file change events?  I'm noticing a need for it in ide-powershell too.