### PR TITLE
Add activation hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
     "atom-languageclient": "0.9.1",
     "javascript-typescript-langserver": "^2.7.0"
   },
+  "activationHooks": [
+    "language-typescript:grammar-used",
+    "language-javascript:grammar-used"
+  ],
   "enhancedScopes": [
     "source.ts",
     "source.tsx",


### PR DESCRIPTION
Every ide-* package activation adds 50-150ms to startup. Is there any good reason not to delay activation until the first related source is open?

<img width="245" alt="screen shot 2018-03-31 at 01 20 36" src="https://user-images.githubusercontent.com/766656/38156874-c408f62e-3481-11e8-95bc-4d615f9f95aa.png">
