### PR TITLE
Autocomplete Suggestion Priority Configuration

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -62,7 +62,7 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
     const autocompleteResultsFirst = atom.config.get('ide-typescript.autocompleteResultsFirst')
     return {
       ...super.provideAutocomplete(),
-      suggestionPriority: autocompleteResultsFirst ? 5 : 1
+      suggestionPriority: autocompleteResultsFirst ? 2 : 1
     }
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -58,6 +58,14 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
     })
   }
 
+  provideAutocomplete() {
+    const autocompleteResultsFirst = atom.config.get('ide-typescript.autocompleteResultsFirst')
+    return {
+      ...super.provideAutocomplete(),
+      suggestionPriority: autocompleteResultsFirst ? 5 : 1
+    }
+  }
+
   onDidConvertAutocomplete(completionItem, suggestion, request) {
     if (suggestion.rightLabel == null || suggestion.displayText == null) return
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,12 @@
       "default": true,
       "description": "Ignore project folders that contain a Flow `.flowconfig` file."
     },
+    "autocompleteResultsFirst": {
+      "type": "boolean",
+      "title": "Show autocomplete results first",
+      "default": true,
+      "description": "Suggestions will be placed before the rest of autocomplete results (e.g. snippets etc). Requires restart to take effect."
+    },
     "returnTypeInAutocomplete": {
       "type": "string",
       "default": "left",


### PR DESCRIPTION
Add an option that allows user to configure autocomplete to their liking. By default, it'll behave how it has been today. Otherwise, it'll have a lower priority, which will allow snippet suggestions to come first.