### PR TITLE
Fix always printing 'Server failed to shutdown' on deactivate

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -33,7 +33,14 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
   }
 
   deactivate() {
-    return Promise.race([super.deactivate(), this.createTimeoutPromise(2000)])
+    let deactivate = super.deactivate();
+    let cancel = new Promise((resolve, reject) => {
+      deactivate.then((result) => {
+        resolve();
+      })
+    });
+
+    return Promise.race([deactivate, this.createTimeoutPromise(2000, cancel)])
   }
 
   shouldStartForEditor(editor) {
@@ -49,12 +56,22 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
     return projectPath != null ? projectPath.path : ''
   }
 
-  createTimeoutPromise(milliseconds) {
+  createTimeoutPromise(milliseconds, cancelPromise) {
+    let cancel = false;
+    cancelPromise.then((result) => {
+      cancel = true;
+    })
+
     return new Promise((resolve, reject) => {
       let timeout = setTimeout(() => {
         clearTimeout(timeout)
-        this.logger.error(`Server failed to shutdown in ${milliseconds}ms, forcing termination`)
-        resolve()
+
+        if(cancel !== true) {
+          this.logger.error(`Server failed to shutdown in ${milliseconds}ms, forcing termination`);
+          resolve();
+        } else {
+          reject();
+        }
       }, milliseconds)
     })
   }


### PR DESCRIPTION
Since the timeout isn't being "cancelled" it would always log the error regardless of if the server succeeded shutting down or not.