### PR TITLE
Expand activation scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,12 +66,10 @@
     "typescript-language-server": "0.3.7"
   },
   "activationHooks": [
-    "language-typescript:grammar-used",
-    "language-javascript:grammar-used",
-    "source.js:root-scope-used",
-    "source.js.jsx:root-scope-used",
     "source.ts:root-scope-used",
-    "source.tsx:root-scope-used"
+    "source.tsx:root-scope-used",
+    "source.js:root-scope-used",
+    "source.js.jsx:root-scope-used"
   ],
   "enhancedScopes": [
     "source.ts",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,11 @@
   },
   "activationHooks": [
     "language-typescript:grammar-used",
-    "language-javascript:grammar-used"
+    "language-javascript:grammar-used",
+    "source.js:root-scope-used",
+    "source.js.jsx:root-scope-used",
+    "source.ts:root-scope-used",
+    "source.tsx:root-scope-used"
   ],
   "enhancedScopes": [
     "source.ts",


### PR DESCRIPTION
#103 was meant to stop this package loading unnecessarily, but it only supported the core JS / TS grammar packages.

This changes the event hooks to be root scope based, which should cover all standard JS(X) and TS(X) grammar root scope names (I compared against the core packages + `language-babel`, and it matches the `extended scopes` section too). As Tree-sitter has settled down, there should be no risk of different scope conventions.

### Alternative designs

We could simply revert #103. I've seen varying reported values from `time-cop`, and it often seems to depend on the order packages happen to load in. Having said that, all my installed `ide-` packages consistently get reported among the biggest time sinks.

closes #151