### PR TITLE
Resolve server path from the project path

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -16,12 +16,12 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
   getLanguageName() { return 'TypeScript' }
   getServerName() { return 'Theia' }
 
-  startServerProcess() {
+  startServerProcess(projectPath) {
     this.supportedExtensions = atom.config.get('ide-typescript.javascriptSupport') ? allExtensions : tsExtensions
     return super.spawnChildNode([
       'node_modules/typescript-language-server/lib/cli',
       '--stdio',
-      '--tsserver-path', atom.config.get('ide-typescript.typeScriptServer.path')
+      '--tsserver-path', this.getServerPath(projectPath)
     ], { cwd: path.join(__dirname, '..') })
   }
 
@@ -43,22 +43,21 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
   }
 
   shouldStartForEditor(editor) {
+    const projectPath = this.getProjectPath(editor.getURI() || '');
     if (atom.config.get('ide-typescript.ignoreFlow') === true) {
-      const flowConfigPath = path.join(this.getProjectPath(editor.getURI() || ''), '.flowconfig')
+      const flowConfigPath = path.join(projectPath, '.flowconfig')
       if (fs.existsSync(flowConfigPath)) return false
     }
 
-    if (!this.validateTypeScriptServerPath()) return false
+    if (!this.validateTypeScriptServerPath(projectPath)) return false
 
     return super.shouldStartForEditor(editor);
   }
 
-  validateTypeScriptServerPath() {
-    const tsSpecifiedPath = atom.config.get('ide-typescript.typeScriptServer.path')
-    const isAbsolutelySpecified = path.isAbsolute(tsSpecifiedPath)
-    const tsAbsolutePath = isAbsolutelySpecified ? tsSpecifiedPath : path.join(__dirname, '..', tsSpecifiedPath)
+  validateTypeScriptServerPath(projectPath) {
+    const tsPath = this.getServerPath(projectPath);
 
-    if (fs.existsSync(tsAbsolutePath)) return true
+    if (fs.existsSync(tsPath)) return true
 
     atom.notifications.addError('ide-typescript could not locate the TypeScript server', {
       dismissable: true,
@@ -66,7 +65,7 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
         { text: 'Set TypeScript server path', onDidClick: () => this.openPackageSettings() },
       ],
       description:
-        `No TypeScript server could be found at <b>${tsAbsolutePath}</b>`
+        `No TypeScript server could be found at <b>${tsPath}</b>`
     })
   }
 
@@ -77,6 +76,15 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
   getProjectPath(filePath) {
     const projectPath = atom.project.getDirectories().find(d => filePath.startsWith(d.path))
     return projectPath != null ? projectPath.path : ''
+  }
+
+  getServerPath(projectPath) {
+    const tsSpecifiedPath = atom.config.get('ide-typescript.typeScriptServer.path')
+    const localPath = path.resolve(projectPath, tsSpecifiedPath)
+    if (fs.existsSync(localPath)) {
+      return localPath
+    }
+    return path.resolve(__dirname, '..', tsSpecifiedPath)
   }
 
   createTimeoutPromise(milliseconds, cancelPromise) {


### PR DESCRIPTION
This PR tries to resolve https://github.com/atom/ide-typescript/issues/154

If a relative path is provided as a `ide-typescript.typeScriptServer.path` option, this patch will try to resolve it from the current project's root directory.
It introduces a breaking change since the relative paths were resolved from the package's installed directory.