### PR TITLE
Bump TSServer & Theia Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
   },
   "dependencies": {
     "atom-languageclient": "0.9.9",
-    "typescript": "~3.1.6",
-    "typescript-language-server": "0.3.7"
+    "typescript": "~3.6.4",
+    "typescript-language-server": "~0.4.0"
   },
   "activationHooks": [
     "source.ts:root-scope-used",


### PR DESCRIPTION
New versions of TSServer when paired with Theia's language server include some very useful features (most notably it now seems to download types for node packages in the background now).

I've tested this throughout various JS repos and have not noticed any regressions.

The reason for the Theia (`typescript-language-server`) semvar major bump is because the package [bumped `monaco-languageclient`](https://github.com/theia-ide/typescript-language-server/commit/167752c9d651e24b1d2c287abf31b605256d3233) which now is [written in ES6](https://github.com/TypeFox/monaco-languageclient/blob/master/CHANGELOG.md#0100---2019-08-26).

### Old:
![image](https://user-images.githubusercontent.com/6043371/66720632-587a4f00-edcd-11e9-97ad-0b0412fad549.png)

![image](https://user-images.githubusercontent.com/6043371/66720636-64fea780-edcd-11e9-89b1-6a3109073dbd.png)


### New:

![image](https://user-images.githubusercontent.com/6043371/66720639-819adf80-edcd-11e9-8194-ea40a4cc1c29.png)

This fixes #158.
This affects #144 by making its impact less widespread (any package with typings will no longer show the warning).