### PR TITLE
fix: false-positive error 'ts server not found' if project wasn't open

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -18,10 +18,13 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
 
   startServerProcess(projectPath) {
     this.supportedExtensions = atom.config.get('ide-typescript.javascriptSupport') ? allExtensions : tsExtensions
+    const serverPath = this.getServerPath(projectPath)
+    console.info(`starting typescript server: ${serverPath}`)
+
     return super.spawnChildNode([
       'node_modules/typescript-language-server/lib/cli',
       '--stdio',
-      '--tsserver-path', this.getServerPath(projectPath)
+      '--tsserver-path', serverPath
     ], { cwd: path.join(__dirname, '..') })
   }
 
@@ -44,6 +47,8 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
 
   shouldStartForEditor(editor) {
     const projectPath = this.getProjectPath(editor.getURI() || '');
+    if (!projectPath) return false
+
     if (atom.config.get('ide-typescript.ignoreFlow') === true) {
       const flowConfigPath = path.join(projectPath, '.flowconfig')
       if (fs.existsSync(flowConfigPath)) return false
@@ -79,12 +84,20 @@ class TypeScriptLanguageClient extends AutoLanguageClient {
   }
 
   getServerPath(projectPath) {
-    const tsSpecifiedPath = atom.config.get('ide-typescript.typeScriptServer.path')
-    const localPath = path.resolve(projectPath, tsSpecifiedPath)
-    if (fs.existsSync(localPath)) {
-      return localPath
+    const relativePathSpecifiedByUser = atom.config.get('ide-typescript.typeScriptServer.path')
+    const relativePathDefault = 'node_modules/typescript/lib/tsserver.js'
+    const absPathLocal = path.resolve(projectPath, relativePathSpecifiedByUser)
+    const absPathGlobal = path.resolve(__dirname, '..', relativePathSpecifiedByUser)
+    const absPathGlobalDefault = path.resolve(__dirname, '..', relativePathDefault)
+
+    if (fs.existsSync(absPathLocal)) {
+      return absPathLocal
     }
-    return path.resolve(__dirname, '..', tsSpecifiedPath)
+    if (fs.existsSync(absPathGlobal)) {
+      return absPathGlobal
+    }
+
+    return absPathGlobalDefault
   }
 
   createTimeoutPromise(milliseconds, cancelPromise) {


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

Didn't create new issue, because this is realted to changes, made in: https://github.com/atom/ide-typescript/issues/154
If to open project without locally specified TS server path, it will show error alert.
Also if to open project with locally specified TS server path, it'll show error alert anyway, because project path is not always set.

### Description of the Change

Just check that path doesn't exist and do nothing.
Also did a little refactor for already added code.

### Alternate Designs

just a fix

### Possible Drawbacks

Didn't find such, use this fix locally for near one month.

### Verification Process

Use this plugin with my typescript project near one month.

### Release Notes

